### PR TITLE
Add MISSING_AS_BYE = 1 to weeklyResults call in ff_starters()

### DIFF
--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/.github/workflows/test-apis.yml
+++ b/.github/workflows/test-apis.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/.github/workflows/test-rebuild.yml
+++ b/.github/workflows/test-rebuild.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/R/mfl_starters.R
+++ b/R/mfl_starters.R
@@ -67,7 +67,7 @@ ff_starters.mfl_conn <- function(conn, week = 1:17, season = NULL, ...) {
 }
 
 .mfl_weeklystarters <- function(week, year, conn) {
-  weekly_result <- mfl_getendpoint(conn, "weeklyResults", W = week, YEAR = year) %>%
+  weekly_result <- mfl_getendpoint(conn, "weeklyResults", W = week, YEAR = year, MISSING_AS_BYE = 1) %>%
     purrr::pluck("content", "weeklyResults", "matchup") %>%
     purrr::map("franchise") %>%
     tibble::tibble()


### PR DESCRIPTION
Adds `MISSING_AS_BYE = 1` to the MFL `weeklyResults` endpoint used by `ff_starters()`.

Without this parameter, submitted starters are missing when a fantasy team has no weekly opponent (i.e. fantasy bye week).

This change aligns `ff_starters()` output with MFL's web interface (which tracks starters regardless of weekly fantasy opponent).

Fixes #393